### PR TITLE
save masteroutput to local csv instead of uploading to google drive

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ def main():
     results_df = run_search_across_companies(companies, custom_search)
 
     # Process the entire results df by removing blacklist results and internal duplicates
-    results_df, master_df = prune_results(results_df, google, google_folder_ids)
+    results_df, master_df = prune_results(results_df)
 
     # Set date retrieved column to be current datetime
     date_retrieved = datetime.now()
@@ -42,17 +42,9 @@ def main():
     date_retrieved_month = date_retrieved.month
     results_df['DATE_RETRIEVED'] = date_retrieved.date()
 
-    # Update master by adding new unique records and upload to drive
+    # Update master by adding new unique records and save locally
     master_df = pd.concat([master_df, results_df], ignore_index=True)
-    master_csv_name = 'masteroutput.csv'
-    master_df.to_csv(master_csv_name, index=False)
-    folder_id = google_folder_ids['master_output_folder_id']
-    upload_successful = google.upload_file_to_drive(master_csv_name, folder_id)
-
-    # Apply expontential backoff if uploading file to drive fails
-    if not upload_successful:
-        apply_exponential_backoff_to_file_upload(google, master_csv_name, folder_id)
-    print('Uploaded new masteroutput sheet to drive.')
+    master_df.to_csv('masteroutput.csv', index=False)
 
     # Create csv name based on date
     csv_name = '{:02d}{:02d}_{}_outputsheet.csv'.format(date_retrieved_month,

--- a/utils/results_pruner.py
+++ b/utils/results_pruner.py
@@ -1,15 +1,9 @@
 import json
 
-
-def _remove_blacklisted_phrases(df):
-    with open('json_library/blacklist.json', 'r') as f:
-        blacklist = json.load(f)
-        blacklist_phrases = blacklist['TEXT']
-    for phrase in blacklist_phrases:
-        df = df[~df.TEXT_PREVIEW.str.contains(phrase)]
-    return df
+import pandas as pd
 
 
+# THIS FUNCTION ISN'T USED ANYMORE - STILL KEEP
 def _get_master_output_sheet(google, id_dict):
     # Get folder id where master output sheet is stored
     folder_id = id_dict['master_output_folder_id']
@@ -31,6 +25,15 @@ def _get_master_output_sheet(google, id_dict):
         exit()
 
 
+def _remove_blacklisted_phrases(df):
+    with open('json_library/blacklist.json', 'r') as f:
+        blacklist = json.load(f)
+        blacklist_phrases = blacklist['TEXT']
+    for phrase in blacklist_phrases:
+        df = df[~df.TEXT_PREVIEW.str.contains(phrase)]
+    return df
+
+
 def _remove_duplicates_in_master(results, master):
     # Remove any rows from results if URL already exists in master
     master_url_list = master['URL'].tolist()
@@ -38,7 +41,7 @@ def _remove_duplicates_in_master(results, master):
     return results
 
 
-def prune_results(df, google, id_dict):
+def prune_results(df):
     # Remove any duplicates based on URL column and return results
     df = df.drop_duplicates(subset='URL', keep="first")
 
@@ -47,8 +50,8 @@ def prune_results(df, google, id_dict):
     print('Dropped internal duplicates and removed blacklisted phrases.')
     df.to_csv("Search Results.csv", index=False)
 
-    # Download master df from drive
-    master_df = _get_master_output_sheet(google, id_dict)
+    # Load masteroutput sheet
+    master_df = pd.read_csv('masteroutput.csv')
 
     # Compare results df to master and remove any duplicates
     df = _remove_duplicates_in_master(df, master_df)


### PR DESCRIPTION
The masteroutput sheet has ~52k rows, and uploading to google drive is timing out and causing the script to fail. We don't actually need this sheet to be on the google drive, we just need to save it and be able to access it easily. This change will just store the masteroutput csv file locally on the machine instead, and use the local copy to check for duplicates, and will omit the uploading to G Drive step. We can still get the sheet off the machine easily when we need it.